### PR TITLE
fix(a11y): announce child added/removed to screen readers on children's application page

### DIFF
--- a/frontend/app/.server/locales/en/protected-application-intake-child.ts
+++ b/frontend/app/.server/locales/en/protected-application-intake-child.ts
@@ -182,6 +182,8 @@ const ns = {
     removeChild: "Remove child",
     removeChildAccessibleName: "Remove child {{childNumber}}",
     removeChildAccessibleNameWithName: "Remove child {{childNumber}}, {{childName}}",
+    childAdded: "A child has been added to your application.",
+    childRemoved: "A child has been removed from your application.",
   },
 } as const;
 

--- a/frontend/app/.server/locales/fr/protected-application-intake-child.ts
+++ b/frontend/app/.server/locales/fr/protected-application-intake-child.ts
@@ -182,6 +182,8 @@ const ns = {
     removeChild: "Retirer l'enfant",
     removeChildAccessibleName: "Retirer l'enfant {{childNumber}}",
     removeChildAccessibleNameWithName: "Retirer l'enfant {{childNumber}}, {{childName}}",
+    childAdded: "Un enfant a été ajouté à votre demande.",
+    childRemoved: "Un enfant a été retiré de votre demande.",
   },
 } as const;
 

--- a/frontend/app/routes/protected/application/intake-children/childrens-application.tsx
+++ b/frontend/app/routes/protected/application/intake-children/childrens-application.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef, useState } from 'react';
+
 import { redirect, useFetcher } from 'react-router';
 
 import { invariant } from '@dts-stn/invariant';
@@ -144,11 +146,30 @@ export default function ProtectedNewChildChildrensApplication({ loaderData, para
   const fetcher = useFetcher<typeof action>();
   const { isSubmitting } = useFetcherSubmissionState(fetcher);
 
+  const [announcement, setAnnouncement] = useState('');
+  const previousChildCountRef = useRef(state.children.length);
+
+  useEffect(() => {
+    const previousChildCount = previousChildCountRef.current;
+    const currentChildCount = state.children.length;
+
+    if (currentChildCount > previousChildCount) {
+      setAnnouncement(t(($) => $.childrensApplication.childAdded));
+    } else if (currentChildCount < previousChildCount) {
+      setAnnouncement(t(($) => $.childrensApplication.childRemoved));
+    }
+
+    previousChildCountRef.current = currentChildCount;
+  }, [state.children.length, t]);
+
   const allChildrenCompleted = state.children.length > 0 && childrenSections.every((child) => Object.values(child.sections).every((section) => section.completed));
 
   return (
     <>
       <AppPageTitle>{t(($) => $.childrensApplication.pageTitle)}</AppPageTitle>
+      <div aria-live="polite" aria-atomic="true" role="status" className="sr-only">
+        {announcement}
+      </div>
       <ProgressStepper activeStep="childrensApplication" className="mb-8" />
       <div className="max-w-prose space-y-8">
         {state.children.map((child, index) => {


### PR DESCRIPTION
### Description
Screen reader users were not informed when a child was added or removed on the
children's application page. This adds an ARIA live region that announces the
change.

- Added a visually-hidden `aria-live="polite"` region to the children's
  application page.
- Announces "A child has been added/removed" when the child count changes
  (nothing is announced on initial page load).

### Related Azure Boards Work Items
[AB#8730](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/8730)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->