### PR TITLE
fix(a11y): Child application - add descriptive accessible name to "Add child" button

### DIFF
--- a/frontend/app/.server/locales/en/application-full-child.ts
+++ b/frontend/app/.server/locales/en/application-full-child.ts
@@ -181,6 +181,7 @@ const ns = {
     backBtn: "Parent or legal guardian information",
     submitBtn: "Submit",
     addChild: "Add a child",
+    addChildAccessibleName: "Add child {{childNumber}}",
     removeChild: "Remove child",
   },
 } as const;

--- a/frontend/app/.server/locales/en/application-full-family.ts
+++ b/frontend/app/.server/locales/en/application-full-family.ts
@@ -201,6 +201,7 @@ const ns = {
     backBtn: "Your access to dental insurance",
     submitBtn: "Submit",
     addChild: "Add a child",
+    addChildAccessibleName: "Add child {{childNumber}}",
     removeChild: "Remove child",
   },
   exitApplication: {

--- a/frontend/app/.server/locales/en/application-simplified-child.ts
+++ b/frontend/app/.server/locales/en/application-simplified-child.ts
@@ -102,6 +102,7 @@ const ns = {
     backBtn: "Parent or legal guardian information",
     submitBtn: "Submit",
     addChild: "Add a child",
+    addChildAccessibleName: "Add child {{childNumber}}",
     removeChild: "Remove child",
     noChange: "No update.",
   },

--- a/frontend/app/.server/locales/en/application-simplified-family.ts
+++ b/frontend/app/.server/locales/en/application-simplified-family.ts
@@ -95,6 +95,7 @@ const ns = {
     backBtn: "Your access to dental insurance",
     submitBtn: "Submit",
     addChild: "Add a child",
+    addChildAccessibleName: "Add child {{childNumber}}",
     removeChild: "Remove child",
     noChange: "No update.",
   },

--- a/frontend/app/.server/locales/en/protected-application-intake-child.ts
+++ b/frontend/app/.server/locales/en/protected-application-intake-child.ts
@@ -178,6 +178,7 @@ const ns = {
     backBtn: "Parent or legal guardian information",
     submitBtn: "Submit",
     addChild: "Add a child",
+    addChildAccessibleName: "Add child {{childNumber}}",
     removeChild: "Remove child",
   },
 } as const;

--- a/frontend/app/.server/locales/en/protected-application-intake-family.ts
+++ b/frontend/app/.server/locales/en/protected-application-intake-family.ts
@@ -198,6 +198,7 @@ const ns = {
     backBtn: "Your access to dental insurance",
     submitBtn: "Submit",
     addChild: "Add a child",
+    addChildAccessibleName: "Add child {{childNumber}}",
     removeChild: "Remove child",
   },
   exitApplication: {

--- a/frontend/app/.server/locales/fr/application-full-child.ts
+++ b/frontend/app/.server/locales/fr/application-full-child.ts
@@ -181,6 +181,7 @@ const ns = {
     backBtn: "Renseignements sur le parent ou le tuteur légal",
     submitBtn: "Soumettre la demande",
     addChild: "Ajouter un enfant",
+    addChildAccessibleName: "Ajouter l'enfant {{childNumber}}",
     removeChild: "Retirer l'enfant",
   },
 } as const;

--- a/frontend/app/.server/locales/fr/application-full-family.ts
+++ b/frontend/app/.server/locales/fr/application-full-family.ts
@@ -201,6 +201,7 @@ const ns = {
     backBtn: "Votre accès à une assurance dentaire",
     submitBtn: "Soumettre",
     addChild: "Ajouter un enfant",
+    addChildAccessibleName: "Ajouter l'enfant {{childNumber}}",
     removeChild: "Retirer l'enfant",
   },
   exitApplication: {

--- a/frontend/app/.server/locales/fr/application-simplified-child.ts
+++ b/frontend/app/.server/locales/fr/application-simplified-child.ts
@@ -102,6 +102,7 @@ const ns = {
     backBtn: "Renseignements sur le parent ou le tuteur légal",
     submitBtn: "Soumettre la demande",
     addChild: "Ajouter un enfant",
+    addChildAccessibleName: "Ajouter l'enfant {{childNumber}}",
     removeChild: "Retirer l'enfant",
     noChange: "Pas de mise à jour.",
   },

--- a/frontend/app/.server/locales/fr/application-simplified-family.ts
+++ b/frontend/app/.server/locales/fr/application-simplified-family.ts
@@ -95,6 +95,7 @@ const ns = {
     backBtn: "Votre accès à une assurance dentaire",
     submitBtn: "Soumettre la demande",
     addChild: "Ajouter un enfant",
+    addChildAccessibleName: "Ajouter l'enfant {{childNumber}}",
     removeChild: "Retirer l'enfant",
     noChange: "Pas de mise à jour.",
   },

--- a/frontend/app/.server/locales/fr/protected-application-intake-child.ts
+++ b/frontend/app/.server/locales/fr/protected-application-intake-child.ts
@@ -178,6 +178,7 @@ const ns = {
     backBtn: "Renseignements sur le parent ou le tuteur légal",
     submitBtn: "Soumettre la demande",
     addChild: "Ajouter un enfant",
+    addChildAccessibleName: "Ajouter l'enfant {{childNumber}}",
     removeChild: "Retirer l'enfant",
   },
 } as const;

--- a/frontend/app/.server/locales/fr/protected-application-intake-family.ts
+++ b/frontend/app/.server/locales/fr/protected-application-intake-family.ts
@@ -198,6 +198,7 @@ const ns = {
     backBtn: "Votre accès à une assurance dentaire",
     submitBtn: "Soumettre",
     addChild: "Ajouter un enfant",
+    addChildAccessibleName: "Ajouter l'enfant {{childNumber}}",
     removeChild: "Retirer l'enfant",
   },
   exitApplication: {

--- a/frontend/app/routes/protected/application/intake-children/childrens-application.tsx
+++ b/frontend/app/routes/protected/application/intake-children/childrens-application.tsx
@@ -341,7 +341,15 @@ export default function ProtectedNewChildChildrensApplication({ loaderData, para
         })}
         <fetcher.Form method="post" noValidate>
           <CsrfTokenInput />
-          <Button variant="primary" id="add-child" name="_action" value={FORM_ACTION.add} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Child:Add child - Child(ren) application click">
+          <Button
+            variant="primary"
+            id="add-child"
+            name="_action"
+            value={FORM_ACTION.add}
+            disabled={isSubmitting}
+            aria-label={t(($) => $.childrensApplication.addChildAccessibleName, { childNumber: state.children.length + 1 })}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Child:Add child - Child(ren) application click"
+          >
             {t(($) => $.childrensApplication.addChild)}
           </Button>
         </fetcher.Form>

--- a/frontend/app/routes/protected/application/intake-family/childrens-application.tsx
+++ b/frontend/app/routes/protected/application/intake-family/childrens-application.tsx
@@ -319,7 +319,15 @@ export default function ProtectedNewFamilyChildrensApplication({ loaderData, par
         })}
         <fetcher.Form method="post" noValidate>
           <CsrfTokenInput />
-          <Button variant="primary" id="add-child" name="_action" value={FORM_ACTION.add} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Add child - Child(ren) application click">
+          <Button
+            variant="primary"
+            id="add-child"
+            name="_action"
+            value={FORM_ACTION.add}
+            disabled={isSubmitting}
+            aria-label={t(($) => $.childrensApplication.addChildAccessibleName, { childNumber: state.children.length + 1 })}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Add child - Child(ren) application click"
+          >
             {t(($) => $.childrensApplication.addChild)}
           </Button>
         </fetcher.Form>

--- a/frontend/app/routes/public/application/full-children/childrens-application.tsx
+++ b/frontend/app/routes/public/application/full-children/childrens-application.tsx
@@ -340,7 +340,15 @@ export default function NewChildChildrensApplication({ loaderData, params }: Rou
         })}
         <fetcher.Form method="post" noValidate>
           <CsrfTokenInput />
-          <Button variant="primary" id="add-child" name="_action" value={FORM_ACTION.add} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Child:Add child - Child(ren) application click">
+          <Button
+            variant="primary"
+            id="add-child"
+            name="_action"
+            value={FORM_ACTION.add}
+            disabled={isSubmitting}
+            aria-label={t(($) => $.childrensApplication.addChildAccessibleName, { childNumber: state.children.length + 1 })}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Child:Add child - Child(ren) application click"
+          >
             {t(($) => $.childrensApplication.addChild)}
           </Button>
         </fetcher.Form>

--- a/frontend/app/routes/public/application/full-family/childrens-application.tsx
+++ b/frontend/app/routes/public/application/full-family/childrens-application.tsx
@@ -319,7 +319,15 @@ export default function NewFamilyChildrensApplication({ loaderData, params }: Ro
         })}
         <fetcher.Form method="post" noValidate>
           <CsrfTokenInput />
-          <Button variant="primary" id="add-child" name="_action" value={FORM_ACTION.add} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Add child - Child(ren) application click">
+          <Button
+            variant="primary"
+            id="add-child"
+            name="_action"
+            value={FORM_ACTION.add}
+            disabled={isSubmitting}
+            aria-label={t(($) => $.childrensApplication.addChildAccessibleName, { childNumber: state.children.length + 1 })}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Add child - Child(ren) application click"
+          >
             {t(($) => $.childrensApplication.addChild)}
           </Button>
         </fetcher.Form>

--- a/frontend/app/routes/public/application/simplified-children/childrens-application.tsx
+++ b/frontend/app/routes/public/application/simplified-children/childrens-application.tsx
@@ -383,7 +383,15 @@ export default function RenewChildChildrensApplication({ loaderData, params }: R
         })}
         <fetcher.Form method="post" noValidate>
           <CsrfTokenInput />
-          <Button variant="primary" id="add-child" name="_action" value={FORM_ACTION.add} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Renewal Form-Child:Add child - Child(ren) application click">
+          <Button
+            variant="primary"
+            id="add-child"
+            name="_action"
+            value={FORM_ACTION.add}
+            disabled={isSubmitting}
+            aria-label={t(($) => $.childrensApplication.addChildAccessibleName, { childNumber: state.children.length + 1 })}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Renewal Form-Child:Add child - Child(ren) application click"
+          >
             {t(($) => $.childrensApplication.addChild)}
           </Button>
         </fetcher.Form>

--- a/frontend/app/routes/public/application/simplified-family/childrens-application.tsx
+++ b/frontend/app/routes/public/application/simplified-family/childrens-application.tsx
@@ -382,7 +382,15 @@ export default function RenewFamilyChildrensApplication({ loaderData, params }: 
         })}
         <fetcher.Form method="post" noValidate>
           <CsrfTokenInput />
-          <Button variant="primary" id="add-child" name="_action" value={FORM_ACTION.add} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Renewal Form-Family:Add child - Child(ren) application click">
+          <Button
+            variant="primary"
+            id="add-child"
+            name="_action"
+            value={FORM_ACTION.add}
+            disabled={isSubmitting}
+            aria-label={t(($) => $.childrensApplication.addChildAccessibleName, { childNumber: state.children.length + 1 })}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Renewal Form-Family:Add child - Child(ren) application click"
+          >
             {t(($) => $.childrensApplication.addChild)}
           </Button>
         </fetcher.Form>


### PR DESCRIPTION
### Description
Gives the "Add a child" button a localized accessible name that identifies the
next child to be added, so screen reader users get clearer
context about what the button will do. The visible button label is unchanged.

This is PR 1 of 4 splitting the child-listing a11y work.

### Related Azure Boards Work Items
[AB#8730](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/8730)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->