### PR TITLE
Move country field to top of address forms

### DIFF
--- a/frontend/app/routes/protected/application/spokes/home-address.tsx
+++ b/frontend/app/routes/protected/application/spokes/home-address.tsx
@@ -268,6 +268,18 @@ export default function HomeAddress({ loaderData, params }: Route.ComponentProps
           <fetcher.Form method="post" noValidate>
             <CsrfTokenInput />
             <div className="mb-8 space-y-6">
+              <InputSelect
+                id="home-country"
+                name="countryId"
+                className="w-full sm:w-1/2"
+                label={t(($) => $.address.addressField.country)}
+                autoComplete="country"
+                defaultValue={defaultState.country ?? ''}
+                errorMessage={errors?.countryId}
+                options={countries}
+                onChange={homeCountryChangeHandler}
+                required
+              />
               <InputSanitizeField
                 id="homeAddress"
                 name="address"
@@ -319,18 +331,6 @@ export default function HomeAddress({ loaderData, params }: Route.ComponentProps
                   required
                 />
               )}
-              <InputSelect
-                id="home-country"
-                name="countryId"
-                className="w-full sm:w-1/2"
-                label={t(($) => $.address.addressField.country)}
-                autoComplete="country"
-                defaultValue={defaultState.country ?? ''}
-                errorMessage={errors?.countryId}
-                options={countries}
-                onChange={homeCountryChangeHandler}
-                required
-              />
             </div>
             <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
               <Dialog open={addressDialogContent !== undefined} onOpenChange={onDialogOpenChangeHandler}>

--- a/frontend/app/routes/protected/application/spokes/mailing-address.tsx
+++ b/frontend/app/routes/protected/application/spokes/mailing-address.tsx
@@ -304,6 +304,18 @@ export default function MailingAddress({ loaderData, params }: Route.ComponentPr
           <fetcher.Form method="post" noValidate>
             <CsrfTokenInput />
             <div className="mb-8 space-y-6">
+              <InputSelect
+                id="mailing-country"
+                name="countryId"
+                className="w-full sm:w-1/2"
+                label={t(($) => $.address.addressField.country)}
+                autoComplete="country"
+                defaultValue={defaultState.country}
+                errorMessage={errors?.countryId}
+                options={countries}
+                onChange={mailingCountryChangeHandler}
+                required
+              />
               <InputSanitizeField
                 id="mailingAddress"
                 name="address"
@@ -355,18 +367,6 @@ export default function MailingAddress({ loaderData, params }: Route.ComponentPr
                   required
                 />
               )}
-              <InputSelect
-                id="mailing-country"
-                name="countryId"
-                className="w-full sm:w-1/2"
-                label={t(($) => $.address.addressField.country)}
-                autoComplete="country"
-                defaultValue={defaultState.country}
-                errorMessage={errors?.countryId}
-                options={countries}
-                onChange={mailingCountryChangeHandler}
-                required
-              />
               <InputCheckbox id="sync-addresses" name="syncAddresses" value="true" checked={copyAddressChecked} onChange={checkHandler}>
                 {t(($) => $.address.homeAddress.useMailingAddress)}
               </InputCheckbox>

--- a/frontend/app/routes/protected/profile/home-address.tsx
+++ b/frontend/app/routes/protected/profile/home-address.tsx
@@ -300,6 +300,18 @@ export default function EditHomeAddress({ loaderData, params }: Route.ComponentP
           <fetcher.Form method="post" noValidate>
             <CsrfTokenInput />
             <div className="mb-8 space-y-6">
+              <InputSelect
+                id="home-country"
+                name="countryId"
+                className="w-full sm:w-1/2"
+                label={t(($) => $.homeAddress.country)}
+                autoComplete="country"
+                defaultValue={defaultState.country}
+                errorMessage={errors?.countryId}
+                options={countries}
+                onChange={homeCountryChangeHandler}
+                required
+              />
               <InputSanitizeField
                 id="homeAddress"
                 name="address"
@@ -351,18 +363,6 @@ export default function EditHomeAddress({ loaderData, params }: Route.ComponentP
                   required
                 />
               )}
-              <InputSelect
-                id="home-country"
-                name="countryId"
-                className="w-full sm:w-1/2"
-                label={t(($) => $.homeAddress.country)}
-                autoComplete="country"
-                defaultValue={defaultState.country}
-                errorMessage={errors?.countryId}
-                options={countries}
-                onChange={homeCountryChangeHandler}
-                required
-              />
             </div>
             <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
               <Dialog open={addressDialogContent !== undefined} onOpenChange={onDialogOpenChangeHandler}>

--- a/frontend/app/routes/protected/profile/mailing-address.tsx
+++ b/frontend/app/routes/protected/profile/mailing-address.tsx
@@ -320,6 +320,18 @@ export default function EditMailingAddress({ loaderData, params }: Route.Compone
           <fetcher.Form method="post" noValidate>
             <CsrfTokenInput />
             <div className="mb-8 space-y-6">
+              <InputSelect
+                id="mailing-country"
+                name="countryId"
+                className="w-full sm:w-1/2"
+                label={t(($) => $.mailingAddress.country)}
+                autoComplete="country"
+                defaultValue={defaultState.country}
+                errorMessage={errors?.countryId}
+                options={countries}
+                onChange={mailingCountryChangeHandler}
+                required
+              />
               <InputSanitizeField
                 id="mailingAddress"
                 name="address"
@@ -371,18 +383,6 @@ export default function EditMailingAddress({ loaderData, params }: Route.Compone
                   required
                 />
               )}
-              <InputSelect
-                id="mailing-country"
-                name="countryId"
-                className="w-full sm:w-1/2"
-                label={t(($) => $.mailingAddress.country)}
-                autoComplete="country"
-                defaultValue={defaultState.country}
-                errorMessage={errors?.countryId}
-                options={countries}
-                onChange={mailingCountryChangeHandler}
-                required
-              />
               <InputCheckbox id="sync-addresses" name="syncAddresses" value="true" checked={copyAddressChecked} onChange={checkHandler}>
                 {t(($) => $.mailingAddress.useMailingAddress)}
               </InputCheckbox>

--- a/frontend/app/routes/public/application/spokes/home-address.tsx
+++ b/frontend/app/routes/public/application/spokes/home-address.tsx
@@ -265,6 +265,18 @@ export default function HomeAddress({ loaderData, params }: Route.ComponentProps
           <fetcher.Form method="post" noValidate>
             <CsrfTokenInput />
             <div className="mb-8 space-y-6">
+              <InputSelect
+                id="home-country"
+                name="countryId"
+                className="w-full sm:w-1/2"
+                label={t(($) => $.address.addressField.country)}
+                autoComplete="country"
+                defaultValue={defaultState.country ?? ''}
+                errorMessage={errors?.countryId}
+                options={countries}
+                onChange={homeCountryChangeHandler}
+                required
+              />
               <InputSanitizeField
                 id="homeAddress"
                 name="address"
@@ -316,18 +328,6 @@ export default function HomeAddress({ loaderData, params }: Route.ComponentProps
                   required
                 />
               )}
-              <InputSelect
-                id="home-country"
-                name="countryId"
-                className="w-full sm:w-1/2"
-                label={t(($) => $.address.addressField.country)}
-                autoComplete="country"
-                defaultValue={defaultState.country ?? ''}
-                errorMessage={errors?.countryId}
-                options={countries}
-                onChange={homeCountryChangeHandler}
-                required
-              />
             </div>
             <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
               <Dialog open={addressDialogContent !== undefined} onOpenChange={onDialogOpenChangeHandler}>

--- a/frontend/app/routes/public/application/spokes/mailing-address.tsx
+++ b/frontend/app/routes/public/application/spokes/mailing-address.tsx
@@ -301,6 +301,18 @@ export default function MailingAddress({ loaderData, params }: Route.ComponentPr
           <fetcher.Form method="post" noValidate>
             <CsrfTokenInput />
             <div className="mb-8 space-y-6">
+              <InputSelect
+                id="mailing-country"
+                name="countryId"
+                className="w-full sm:w-1/2"
+                label={t(($) => $.address.addressField.country)}
+                autoComplete="country"
+                defaultValue={defaultState.country}
+                errorMessage={errors?.countryId}
+                options={countries}
+                onChange={mailingCountryChangeHandler}
+                required
+              />
               <InputSanitizeField
                 id="mailingAddress"
                 name="address"
@@ -352,18 +364,6 @@ export default function MailingAddress({ loaderData, params }: Route.ComponentPr
                   required
                 />
               )}
-              <InputSelect
-                id="mailing-country"
-                name="countryId"
-                className="w-full sm:w-1/2"
-                label={t(($) => $.address.addressField.country)}
-                autoComplete="country"
-                defaultValue={defaultState.country}
-                errorMessage={errors?.countryId}
-                options={countries}
-                onChange={mailingCountryChangeHandler}
-                required
-              />
               <InputCheckbox id="sync-addresses" name="syncAddresses" value="true" checked={copyAddressChecked} onChange={checkHandler}>
                 {t(($) => $.address.homeAddress.useMailingAddress)}
               </InputCheckbox>


### PR DESCRIPTION
### Description
Reorders the address form fields so the country selector appears first, before
the street address. Since the province/state options and postal/zip code rules
depend on the selected country, choosing the country first gives users a more
logical top-down flow.

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->