### PR TITLE
a11y: add descriptive accessible name to "Remove child" button

### DIFF
--- a/frontend/app/.server/locales/en/application-full-child.ts
+++ b/frontend/app/.server/locales/en/application-full-child.ts
@@ -183,6 +183,8 @@ const ns = {
     addChild: "Add a child",
     addChildAccessibleName: "Add child {{childNumber}}",
     removeChild: "Remove child",
+    removeChildAccessibleName: "Remove child {{childNumber}}",
+    removeChildAccessibleNameWithName: "Remove child {{childNumber}}, {{childName}}",
   },
 } as const;
 

--- a/frontend/app/.server/locales/en/application-full-family.ts
+++ b/frontend/app/.server/locales/en/application-full-family.ts
@@ -203,6 +203,8 @@ const ns = {
     addChild: "Add a child",
     addChildAccessibleName: "Add child {{childNumber}}",
     removeChild: "Remove child",
+    removeChildAccessibleName: "Remove child {{childNumber}}",
+    removeChildAccessibleNameWithName: "Remove child {{childNumber}}, {{childName}}",
   },
   exitApplication: {
     pageTitle: "Exiting the application",

--- a/frontend/app/.server/locales/en/application-simplified-child.ts
+++ b/frontend/app/.server/locales/en/application-simplified-child.ts
@@ -104,6 +104,8 @@ const ns = {
     addChild: "Add a child",
     addChildAccessibleName: "Add child {{childNumber}}",
     removeChild: "Remove child",
+    removeChildAccessibleName: "Remove child {{childNumber}}",
+    removeChildAccessibleNameWithName: "Remove child {{childNumber}}, {{childName}}",
     noChange: "No update.",
   },
   confirm: {

--- a/frontend/app/.server/locales/en/application-simplified-family.ts
+++ b/frontend/app/.server/locales/en/application-simplified-family.ts
@@ -97,6 +97,8 @@ const ns = {
     addChild: "Add a child",
     addChildAccessibleName: "Add child {{childNumber}}",
     removeChild: "Remove child",
+    removeChildAccessibleName: "Remove child {{childNumber}}",
+    removeChildAccessibleNameWithName: "Remove child {{childNumber}}, {{childName}}",
     noChange: "No update.",
   },
   submit: {

--- a/frontend/app/.server/locales/en/protected-application-intake-child.ts
+++ b/frontend/app/.server/locales/en/protected-application-intake-child.ts
@@ -180,6 +180,8 @@ const ns = {
     addChild: "Add a child",
     addChildAccessibleName: "Add child {{childNumber}}",
     removeChild: "Remove child",
+    removeChildAccessibleName: "Remove child {{childNumber}}",
+    removeChildAccessibleNameWithName: "Remove child {{childNumber}}, {{childName}}",
   },
 } as const;
 

--- a/frontend/app/.server/locales/en/protected-application-intake-family.ts
+++ b/frontend/app/.server/locales/en/protected-application-intake-family.ts
@@ -200,6 +200,8 @@ const ns = {
     addChild: "Add a child",
     addChildAccessibleName: "Add child {{childNumber}}",
     removeChild: "Remove child",
+    removeChildAccessibleName: "Remove child {{childNumber}}",
+    removeChildAccessibleNameWithName: "Remove child {{childNumber}}, {{childName}}",
   },
   exitApplication: {
     pageTitle: "Exiting the application",

--- a/frontend/app/.server/locales/fr/application-full-child.ts
+++ b/frontend/app/.server/locales/fr/application-full-child.ts
@@ -183,6 +183,8 @@ const ns = {
     addChild: "Ajouter un enfant",
     addChildAccessibleName: "Ajouter l'enfant {{childNumber}}",
     removeChild: "Retirer l'enfant",
+    removeChildAccessibleName: "Retirer l'enfant {{childNumber}}",
+    removeChildAccessibleNameWithName: "Retirer l'enfant {{childNumber}}, {{childName}}",
   },
 } as const;
 

--- a/frontend/app/.server/locales/fr/application-full-family.ts
+++ b/frontend/app/.server/locales/fr/application-full-family.ts
@@ -203,6 +203,8 @@ const ns = {
     addChild: "Ajouter un enfant",
     addChildAccessibleName: "Ajouter l'enfant {{childNumber}}",
     removeChild: "Retirer l'enfant",
+    removeChildAccessibleName: "Retirer l'enfant {{childNumber}}",
+    removeChildAccessibleNameWithName: "Retirer l'enfant {{childNumber}}, {{childName}}",
   },
   exitApplication: {
     pageTitle: "Quitter la demande",

--- a/frontend/app/.server/locales/fr/application-simplified-child.ts
+++ b/frontend/app/.server/locales/fr/application-simplified-child.ts
@@ -104,6 +104,8 @@ const ns = {
     addChild: "Ajouter un enfant",
     addChildAccessibleName: "Ajouter l'enfant {{childNumber}}",
     removeChild: "Retirer l'enfant",
+    removeChildAccessibleName: "Retirer l'enfant {{childNumber}}",
+    removeChildAccessibleNameWithName: "Retirer l'enfant {{childNumber}}, {{childName}}",
     noChange: "Pas de mise à jour.",
   },
   confirm: {

--- a/frontend/app/.server/locales/fr/application-simplified-family.ts
+++ b/frontend/app/.server/locales/fr/application-simplified-family.ts
@@ -97,6 +97,8 @@ const ns = {
     addChild: "Ajouter un enfant",
     addChildAccessibleName: "Ajouter l'enfant {{childNumber}}",
     removeChild: "Retirer l'enfant",
+    removeChildAccessibleName: "Retirer l'enfant {{childNumber}}",
+    removeChildAccessibleNameWithName: "Retirer l'enfant {{childNumber}}, {{childName}}",
     noChange: "Pas de mise à jour.",
   },
   submit: {

--- a/frontend/app/.server/locales/fr/protected-application-intake-child.ts
+++ b/frontend/app/.server/locales/fr/protected-application-intake-child.ts
@@ -180,6 +180,8 @@ const ns = {
     addChild: "Ajouter un enfant",
     addChildAccessibleName: "Ajouter l'enfant {{childNumber}}",
     removeChild: "Retirer l'enfant",
+    removeChildAccessibleName: "Retirer l'enfant {{childNumber}}",
+    removeChildAccessibleNameWithName: "Retirer l'enfant {{childNumber}}, {{childName}}",
   },
 } as const;
 

--- a/frontend/app/.server/locales/fr/protected-application-intake-family.ts
+++ b/frontend/app/.server/locales/fr/protected-application-intake-family.ts
@@ -200,6 +200,8 @@ const ns = {
     addChild: "Ajouter un enfant",
     addChildAccessibleName: "Ajouter l'enfant {{childNumber}}",
     removeChild: "Retirer l'enfant",
+    removeChildAccessibleName: "Retirer l'enfant {{childNumber}}",
+    removeChildAccessibleNameWithName: "Retirer l'enfant {{childNumber}}, {{childName}}",
   },
   exitApplication: {
     pageTitle: "Quitter la demande",

--- a/frontend/app/routes/protected/application/intake-children/childrens-application.tsx
+++ b/frontend/app/routes/protected/application/intake-children/childrens-application.tsx
@@ -330,6 +330,7 @@ export default function ProtectedNewChildChildrensApplication({ loaderData, para
                     disabled={isSubmitting}
                     variant="secondary"
                     size="sm"
+                    aria-label={child.information ? t(($) => $.childrensApplication.removeChildAccessibleNameWithName, { childNumber: index + 1, childName }) : t(($) => $.childrensApplication.removeChildAccessibleName, { childNumber: index + 1 })}
                     data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Child:Remove child - Child(ren) application click"
                   >
                     {t(($) => $.childrensApplication.removeChild)}

--- a/frontend/app/routes/protected/application/intake-children/childrens-application.tsx
+++ b/frontend/app/routes/protected/application/intake-children/childrens-application.tsx
@@ -160,6 +160,8 @@ export default function ProtectedNewChildChildrensApplication({ loaderData, para
           const sectionCompletedCount = Object.values(sections).filter((section) => section.completed).length;
           const sectionsCount = Object.values(sections).length;
 
+          const deleteAriaLabel = child.information ? t(($) => $.childrensApplication.removeChildAccessibleNameWithName, { childNumber: index + 1, childName }) : t(($) => $.childrensApplication.removeChildAccessibleName, { childNumber: index + 1 });
+
           return (
             <div key={child.id}>
               <h2 className="font-lato mb-4 text-2xl font-bold">
@@ -330,7 +332,7 @@ export default function ProtectedNewChildChildrensApplication({ loaderData, para
                     disabled={isSubmitting}
                     variant="secondary"
                     size="sm"
-                    aria-label={child.information ? t(($) => $.childrensApplication.removeChildAccessibleNameWithName, { childNumber: index + 1, childName }) : t(($) => $.childrensApplication.removeChildAccessibleName, { childNumber: index + 1 })}
+                    aria-label={deleteAriaLabel}
                     data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Child:Remove child - Child(ren) application click"
                   >
                     {t(($) => $.childrensApplication.removeChild)}

--- a/frontend/app/routes/protected/application/intake-family/childrens-application.tsx
+++ b/frontend/app/routes/protected/application/intake-family/childrens-application.tsx
@@ -160,6 +160,8 @@ export default function ProtectedNewFamilyChildrensApplication({ loaderData, par
           const sectionCompletedCount = Object.values(sections).filter((section) => section.completed).length;
           const sectionsCount = Object.values(sections).length;
 
+          const deleteAriaLabel = child.information ? t(($) => $.childrensApplication.removeChildAccessibleNameWithName, { childNumber: index + 1, childName }) : t(($) => $.childrensApplication.removeChildAccessibleName, { childNumber: index + 1 });
+
           return (
             <div key={child.id}>
               <h2 className="font-lato mb-4 text-2xl font-bold">
@@ -308,7 +310,7 @@ export default function ProtectedNewFamilyChildrensApplication({ loaderData, par
                     disabled={isSubmitting}
                     variant="secondary"
                     size="sm"
-                    aria-label={child.information ? t(($) => $.childrensApplication.removeChildAccessibleNameWithName, { childNumber: index + 1, childName }) : t(($) => $.childrensApplication.removeChildAccessibleName, { childNumber: index + 1 })}
+                    aria-label={deleteAriaLabel}
                     data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Remove child - Child(ren) application click"
                   >
                     {t(($) => $.childrensApplication.removeChild)}

--- a/frontend/app/routes/protected/application/intake-family/childrens-application.tsx
+++ b/frontend/app/routes/protected/application/intake-family/childrens-application.tsx
@@ -308,6 +308,7 @@ export default function ProtectedNewFamilyChildrensApplication({ loaderData, par
                     disabled={isSubmitting}
                     variant="secondary"
                     size="sm"
+                    aria-label={child.information ? t(($) => $.childrensApplication.removeChildAccessibleNameWithName, { childNumber: index + 1, childName }) : t(($) => $.childrensApplication.removeChildAccessibleName, { childNumber: index + 1 })}
                     data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Remove child - Child(ren) application click"
                   >
                     {t(($) => $.childrensApplication.removeChild)}

--- a/frontend/app/routes/public/application/full-children/childrens-application.tsx
+++ b/frontend/app/routes/public/application/full-children/childrens-application.tsx
@@ -329,6 +329,7 @@ export default function NewChildChildrensApplication({ loaderData, params }: Rou
                     disabled={isSubmitting}
                     variant="secondary"
                     size="sm"
+                    aria-label={child.information ? t(($) => $.childrensApplication.removeChildAccessibleNameWithName, { childNumber: index + 1, childName }) : t(($) => $.childrensApplication.removeChildAccessibleName, { childNumber: index + 1 })}
                     data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Child:Remove child - Child(ren) application click"
                   >
                     {t(($) => $.childrensApplication.removeChild)}

--- a/frontend/app/routes/public/application/full-children/childrens-application.tsx
+++ b/frontend/app/routes/public/application/full-children/childrens-application.tsx
@@ -159,6 +159,8 @@ export default function NewChildChildrensApplication({ loaderData, params }: Rou
           const sectionCompletedCount = Object.values(sections).filter((section) => section.completed).length;
           const sectionsCount = Object.values(sections).length;
 
+          const deleteAriaLabel = child.information ? t(($) => $.childrensApplication.removeChildAccessibleNameWithName, { childNumber: index + 1, childName }) : t(($) => $.childrensApplication.removeChildAccessibleName, { childNumber: index + 1 });
+
           return (
             <div key={child.id}>
               <h2 className="font-lato mb-4 text-2xl font-bold">
@@ -329,7 +331,7 @@ export default function NewChildChildrensApplication({ loaderData, params }: Rou
                     disabled={isSubmitting}
                     variant="secondary"
                     size="sm"
-                    aria-label={child.information ? t(($) => $.childrensApplication.removeChildAccessibleNameWithName, { childNumber: index + 1, childName }) : t(($) => $.childrensApplication.removeChildAccessibleName, { childNumber: index + 1 })}
+                    aria-label={deleteAriaLabel}
                     data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Child:Remove child - Child(ren) application click"
                   >
                     {t(($) => $.childrensApplication.removeChild)}

--- a/frontend/app/routes/public/application/full-family/childrens-application.tsx
+++ b/frontend/app/routes/public/application/full-family/childrens-application.tsx
@@ -160,6 +160,8 @@ export default function NewFamilyChildrensApplication({ loaderData, params }: Ro
           const sectionCompletedCount = Object.values(sections).filter((section) => section.completed).length;
           const sectionsCount = Object.values(sections).length;
 
+          const deleteAriaLabel = child.information ? t(($) => $.childrensApplication.removeChildAccessibleNameWithName, { childNumber: index + 1, childName }) : t(($) => $.childrensApplication.removeChildAccessibleName, { childNumber: index + 1 });
+
           return (
             <div key={child.id}>
               <h2 className="font-lato mb-4 text-2xl font-bold">
@@ -308,7 +310,7 @@ export default function NewFamilyChildrensApplication({ loaderData, params }: Ro
                     disabled={isSubmitting}
                     variant="secondary"
                     size="sm"
-                    aria-label={child.information ? t(($) => $.childrensApplication.removeChildAccessibleNameWithName, { childNumber: index + 1, childName }) : t(($) => $.childrensApplication.removeChildAccessibleName, { childNumber: index + 1 })}
+                    aria-label={deleteAriaLabel}
                     data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Remove child - Child(ren) application click"
                   >
                     {t(($) => $.childrensApplication.removeChild)}

--- a/frontend/app/routes/public/application/full-family/childrens-application.tsx
+++ b/frontend/app/routes/public/application/full-family/childrens-application.tsx
@@ -308,6 +308,7 @@ export default function NewFamilyChildrensApplication({ loaderData, params }: Ro
                     disabled={isSubmitting}
                     variant="secondary"
                     size="sm"
+                    aria-label={child.information ? t(($) => $.childrensApplication.removeChildAccessibleNameWithName, { childNumber: index + 1, childName }) : t(($) => $.childrensApplication.removeChildAccessibleName, { childNumber: index + 1 })}
                     data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Remove child - Child(ren) application click"
                   >
                     {t(($) => $.childrensApplication.removeChild)}

--- a/frontend/app/routes/public/application/simplified-children/childrens-application.tsx
+++ b/frontend/app/routes/public/application/simplified-children/childrens-application.tsx
@@ -181,6 +181,8 @@ export default function RenewChildChildrensApplication({ loaderData, params }: R
           invariant(sections, `Expected child sections to be defined for child ${child.id}`);
           const completedSectionsCount = Object.values(sections).filter((section) => section.completed).length;
 
+          const deleteAriaLabel = child.information ? t(($) => $.childrensApplication.removeChildAccessibleNameWithName, { childNumber: index + 1, childName }) : t(($) => $.childrensApplication.removeChildAccessibleName, { childNumber: index + 1 });
+
           return (
             <div key={child.id}>
               <h2 className="font-lato mb-4 text-2xl font-bold">
@@ -372,7 +374,7 @@ export default function RenewChildChildrensApplication({ loaderData, params }: R
                     disabled={isSubmitting}
                     variant="secondary"
                     size="sm"
-                    aria-label={child.information ? t(($) => $.childrensApplication.removeChildAccessibleNameWithName, { childNumber: index + 1, childName }) : t(($) => $.childrensApplication.removeChildAccessibleName, { childNumber: index + 1 })}
+                    aria-label={deleteAriaLabel}
                     data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Renewal Form-Child:Remove child - Child(ren) application click"
                   >
                     {t(($) => $.childrensApplication.removeChild)}

--- a/frontend/app/routes/public/application/simplified-children/childrens-application.tsx
+++ b/frontend/app/routes/public/application/simplified-children/childrens-application.tsx
@@ -372,6 +372,7 @@ export default function RenewChildChildrensApplication({ loaderData, params }: R
                     disabled={isSubmitting}
                     variant="secondary"
                     size="sm"
+                    aria-label={child.information ? t(($) => $.childrensApplication.removeChildAccessibleNameWithName, { childNumber: index + 1, childName }) : t(($) => $.childrensApplication.removeChildAccessibleName, { childNumber: index + 1 })}
                     data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Renewal Form-Child:Remove child - Child(ren) application click"
                   >
                     {t(($) => $.childrensApplication.removeChild)}

--- a/frontend/app/routes/public/application/simplified-family/childrens-application.tsx
+++ b/frontend/app/routes/public/application/simplified-family/childrens-application.tsx
@@ -180,6 +180,8 @@ export default function RenewFamilyChildrensApplication({ loaderData, params }: 
           invariant(sections, `Expected child sections to be defined for child ${child.id}`);
           const completedSectionsCount = Object.values(sections).filter((section) => section.completed).length;
 
+          const deleteAriaLabel = child.information ? t(($) => $.childrensApplication.removeChildAccessibleNameWithName, { childNumber: index + 1, childName }) : t(($) => $.childrensApplication.removeChildAccessibleName, { childNumber: index + 1 });
+
           return (
             <div key={child.id}>
               <h2 className="font-lato mb-4 text-2xl font-bold">
@@ -371,7 +373,7 @@ export default function RenewFamilyChildrensApplication({ loaderData, params }: 
                     disabled={isSubmitting}
                     variant="secondary"
                     size="sm"
-                    aria-label={child.information ? t(($) => $.childrensApplication.removeChildAccessibleNameWithName, { childNumber: index + 1, childName }) : t(($) => $.childrensApplication.removeChildAccessibleName, { childNumber: index + 1 })}
+                    aria-label={deleteAriaLabel}
                     data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Renewal Form-Family:Remove child - Child(ren) application click"
                   >
                     {t(($) => $.childrensApplication.removeChild)}

--- a/frontend/app/routes/public/application/simplified-family/childrens-application.tsx
+++ b/frontend/app/routes/public/application/simplified-family/childrens-application.tsx
@@ -371,6 +371,7 @@ export default function RenewFamilyChildrensApplication({ loaderData, params }: 
                     disabled={isSubmitting}
                     variant="secondary"
                     size="sm"
+                    aria-label={child.information ? t(($) => $.childrensApplication.removeChildAccessibleNameWithName, { childNumber: index + 1, childName }) : t(($) => $.childrensApplication.removeChildAccessibleName, { childNumber: index + 1 })}
                     data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Renewal Form-Family:Remove child - Child(ren) application click"
                   >
                     {t(($) => $.childrensApplication.removeChild)}


### PR DESCRIPTION
### Description

Gives each "Remove child" button a localized accessible name that identifies the
affected child, so screen reader users know exactly which child a Remove button
will delete. The visible button label is unchanged.

This is PR 2 of 4 splitting the child-listing a11y work.

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->