### PR TITLE
fix(a11y): announce correct message when removing a child

### DIFF
--- a/frontend/app/.server/locales/en/application-full-child.ts
+++ b/frontend/app/.server/locales/en/application-full-child.ts
@@ -186,6 +186,8 @@ const ns = {
     removeChildAccessibleName: "Remove child {{childNumber}}",
     removeChildAccessibleNameWithName: "Remove child {{childNumber}}, {{childName}}",
     childAddedAnnouncement: "Child {{childNumber}} was added successfully.",
+    childRemovedAnnouncement: "Child {{childNumber}} was removed successfully.",
+    childRemovedAnnouncementWithName: "Child {{childNumber}}, {{childName}}, was removed successfully.",
   },
 } as const;
 

--- a/frontend/app/.server/locales/en/application-full-family.ts
+++ b/frontend/app/.server/locales/en/application-full-family.ts
@@ -206,6 +206,8 @@ const ns = {
     removeChildAccessibleName: "Remove child {{childNumber}}",
     removeChildAccessibleNameWithName: "Remove child {{childNumber}}, {{childName}}",
     childAddedAnnouncement: "Child {{childNumber}} was added successfully.",
+    childRemovedAnnouncement: "Child {{childNumber}} was removed successfully.",
+    childRemovedAnnouncementWithName: "Child {{childNumber}}, {{childName}}, was removed successfully.",
   },
   exitApplication: {
     pageTitle: "Exiting the application",

--- a/frontend/app/.server/locales/en/application-simplified-child.ts
+++ b/frontend/app/.server/locales/en/application-simplified-child.ts
@@ -107,6 +107,8 @@ const ns = {
     removeChildAccessibleName: "Remove child {{childNumber}}",
     removeChildAccessibleNameWithName: "Remove child {{childNumber}}, {{childName}}",
     childAddedAnnouncement: "Child {{childNumber}} was added successfully.",
+    childRemovedAnnouncement: "Child {{childNumber}} was removed successfully.",
+    childRemovedAnnouncementWithName: "Child {{childNumber}}, {{childName}}, was removed successfully.",
     noChange: "No update.",
   },
   confirm: {

--- a/frontend/app/.server/locales/en/application-simplified-family.ts
+++ b/frontend/app/.server/locales/en/application-simplified-family.ts
@@ -100,6 +100,8 @@ const ns = {
     removeChildAccessibleName: "Remove child {{childNumber}}",
     removeChildAccessibleNameWithName: "Remove child {{childNumber}}, {{childName}}",
     childAddedAnnouncement: "Child {{childNumber}} was added successfully.",
+    childRemovedAnnouncement: "Child {{childNumber}} was removed successfully.",
+    childRemovedAnnouncementWithName: "Child {{childNumber}}, {{childName}}, was removed successfully.",
     noChange: "No update.",
   },
   submit: {

--- a/frontend/app/.server/locales/en/protected-application-intake-child.ts
+++ b/frontend/app/.server/locales/en/protected-application-intake-child.ts
@@ -183,6 +183,8 @@ const ns = {
     removeChildAccessibleName: "Remove child {{childNumber}}",
     removeChildAccessibleNameWithName: "Remove child {{childNumber}}, {{childName}}",
     childAddedAnnouncement: "Child {{childNumber}} was added successfully.",
+    childRemovedAnnouncement: "Child {{childNumber}} was removed successfully.",
+    childRemovedAnnouncementWithName: "Child {{childNumber}}, {{childName}}, was removed successfully.",
   },
 } as const;
 

--- a/frontend/app/.server/locales/en/protected-application-intake-family.ts
+++ b/frontend/app/.server/locales/en/protected-application-intake-family.ts
@@ -203,6 +203,8 @@ const ns = {
     removeChildAccessibleName: "Remove child {{childNumber}}",
     removeChildAccessibleNameWithName: "Remove child {{childNumber}}, {{childName}}",
     childAddedAnnouncement: "Child {{childNumber}} was added successfully.",
+    childRemovedAnnouncement: "Child {{childNumber}} was removed successfully.",
+    childRemovedAnnouncementWithName: "Child {{childNumber}}, {{childName}}, was removed successfully.",
   },
   exitApplication: {
     pageTitle: "Exiting the application",

--- a/frontend/app/.server/locales/fr/application-full-child.ts
+++ b/frontend/app/.server/locales/fr/application-full-child.ts
@@ -186,6 +186,8 @@ const ns = {
     removeChildAccessibleName: "Retirer l'enfant {{childNumber}}",
     removeChildAccessibleNameWithName: "Retirer l'enfant {{childNumber}}, {{childName}}",
     childAddedAnnouncement: "L'enfant {{childNumber}} a été ajouté avec succès.",
+    childRemovedAnnouncement: "L'enfant {{childNumber}} a été retiré avec succès.",
+    childRemovedAnnouncementWithName: "L'enfant {{childNumber}}, {{childName}}, a été retiré avec succès.",
   },
 } as const;
 

--- a/frontend/app/.server/locales/fr/application-full-family.ts
+++ b/frontend/app/.server/locales/fr/application-full-family.ts
@@ -206,6 +206,8 @@ const ns = {
     removeChildAccessibleName: "Retirer l'enfant {{childNumber}}",
     removeChildAccessibleNameWithName: "Retirer l'enfant {{childNumber}}, {{childName}}",
     childAddedAnnouncement: "L'enfant {{childNumber}} a été ajouté avec succès.",
+    childRemovedAnnouncement: "L'enfant {{childNumber}} a été retiré avec succès.",
+    childRemovedAnnouncementWithName: "L'enfant {{childNumber}}, {{childName}}, a été retiré avec succès.",
   },
   exitApplication: {
     pageTitle: "Quitter la demande",

--- a/frontend/app/.server/locales/fr/application-simplified-child.ts
+++ b/frontend/app/.server/locales/fr/application-simplified-child.ts
@@ -107,6 +107,8 @@ const ns = {
     removeChildAccessibleName: "Retirer l'enfant {{childNumber}}",
     removeChildAccessibleNameWithName: "Retirer l'enfant {{childNumber}}, {{childName}}",
     childAddedAnnouncement: "L'enfant {{childNumber}} a été ajouté avec succès.",
+    childRemovedAnnouncement: "L'enfant {{childNumber}} a été retiré avec succès.",
+    childRemovedAnnouncementWithName: "L'enfant {{childNumber}}, {{childName}}, a été retiré avec succès.",
     noChange: "Pas de mise à jour.",
   },
   confirm: {

--- a/frontend/app/.server/locales/fr/application-simplified-family.ts
+++ b/frontend/app/.server/locales/fr/application-simplified-family.ts
@@ -100,6 +100,8 @@ const ns = {
     removeChildAccessibleName: "Retirer l'enfant {{childNumber}}",
     removeChildAccessibleNameWithName: "Retirer l'enfant {{childNumber}}, {{childName}}",
     childAddedAnnouncement: "L'enfant {{childNumber}} a été ajouté avec succès.",
+    childRemovedAnnouncement: "L'enfant {{childNumber}} a été retiré avec succès.",
+    childRemovedAnnouncementWithName: "L'enfant {{childNumber}}, {{childName}}, a été retiré avec succès.",
     noChange: "Pas de mise à jour.",
   },
   submit: {

--- a/frontend/app/.server/locales/fr/protected-application-intake-child.ts
+++ b/frontend/app/.server/locales/fr/protected-application-intake-child.ts
@@ -183,6 +183,8 @@ const ns = {
     removeChildAccessibleName: "Retirer l'enfant {{childNumber}}",
     removeChildAccessibleNameWithName: "Retirer l'enfant {{childNumber}}, {{childName}}",
     childAddedAnnouncement: "L'enfant {{childNumber}} a été ajouté avec succès.",
+    childRemovedAnnouncement: "L'enfant {{childNumber}} a été retiré avec succès.",
+    childRemovedAnnouncementWithName: "L'enfant {{childNumber}}, {{childName}}, a été retiré avec succès.",
   },
 } as const;
 

--- a/frontend/app/.server/locales/fr/protected-application-intake-family.ts
+++ b/frontend/app/.server/locales/fr/protected-application-intake-family.ts
@@ -203,6 +203,8 @@ const ns = {
     removeChildAccessibleName: "Retirer l'enfant {{childNumber}}",
     removeChildAccessibleNameWithName: "Retirer l'enfant {{childNumber}}, {{childName}}",
     childAddedAnnouncement: "L'enfant {{childNumber}} a été ajouté avec succès.",
+    childRemovedAnnouncement: "L'enfant {{childNumber}} a été retiré avec succès.",
+    childRemovedAnnouncementWithName: "L'enfant {{childNumber}}, {{childName}}, a été retiré avec succès.",
   },
   exitApplication: {
     pageTitle: "Quitter la demande",

--- a/frontend/app/.server/routes/helpers/protected-application-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-application-route-helpers.ts
@@ -424,6 +424,29 @@ export function getSingleChildState({ params, session }: getSingleChildStateArgs
   };
 }
 
+interface RemoveChildStateArgs {
+  params: ApplicationStateParams;
+  session: Session;
+  childId: string;
+}
+
+/**
+ * Removes a single child from protected application state and saves the updated state.
+ * @param args - The arguments.
+ * @returns Metadata about the removed child: its zero-based index, one-based number, and derived full name (if available).
+ */
+export function removeChildState({ params, session, childId }: RemoveChildStateArgs) {
+  const applicationState = getProtectedApplicationState({ params, session });
+  const removedIndex = applicationState.children.findIndex((child) => child.id === childId);
+  const removedChild = applicationState.children[removedIndex];
+  const childName = removedChild?.information ? `${removedChild.information.firstName} ${removedChild.information.lastName}` : undefined;
+  const children = applicationState.children.filter((child) => child.id !== childId);
+
+  saveProtectedApplicationState({ params, session, state: { children } });
+
+  return { removedIndex, childNumber: removedIndex + 1, childName };
+}
+
 /**
  * Checks if the provided date falls within the configured renewal period.
  *

--- a/frontend/app/.server/routes/helpers/public-application-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/public-application-route-helpers.ts
@@ -400,6 +400,29 @@ export function getSingleChildState({ params, session }: getSingleChildStateArgs
   };
 }
 
+interface RemoveChildStateArgs {
+  params: ApplicationStateParams;
+  session: Session;
+  childId: string;
+}
+
+/**
+ * Removes a single child from public application state and saves the updated state.
+ * @param args - The arguments.
+ * @returns Metadata about the removed child: its zero-based index, one-based number, and derived full name (if available).
+ */
+export function removeChildState({ params, session, childId }: RemoveChildStateArgs) {
+  const applicationState = getPublicApplicationState({ params, session });
+  const removedIndex = applicationState.children.findIndex((child) => child.id === childId);
+  const removedChild = applicationState.children[removedIndex];
+  const childName = removedChild?.information ? `${removedChild.information.firstName} ${removedChild.information.lastName}` : undefined;
+  const children = applicationState.children.filter((child) => child.id !== childId);
+
+  savePublicApplicationState({ params, session, state: { children } });
+
+  return { removedIndex, childNumber: removedIndex + 1, childName };
+}
+
 /**
  * Checks if the provided date falls within the configured renewal period.
  *

--- a/frontend/app/routes/protected/application/intake-children/childrens-application.tsx
+++ b/frontend/app/routes/protected/application/intake-children/childrens-application.tsx
@@ -1,4 +1,4 @@
-import { redirect, useFetcher } from 'react-router';
+import { useFetcher } from 'react-router';
 
 import { invariant } from '@dts-stn/invariant';
 import { faCirclePlus, faPenToSquare } from '@fortawesome/free-solid-svg-icons';
@@ -27,7 +27,6 @@ import { ProgressStepper } from '~/routes/protected/application/intake-children/
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { generateId } from '~/utils/id-utils';
 import { mergeMeta } from '~/utils/meta-utils';
-import { getPathById } from '~/utils/route-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
@@ -125,7 +124,10 @@ export async function action({ context, params, request, url }: Route.ActionArgs
   }
 
   const removeChildId = formData.get('childId');
-  const children = [...state.children].filter((child) => child.id !== removeChildId);
+  const removedIndex = state.children.findIndex((child) => child.id === removeChildId);
+  const removedChild = state.children[removedIndex];
+  const removedChildName = removedChild?.information ? `${removedChild.information.firstName} ${removedChild.information.lastName}` : undefined;
+  const children = state.children.filter((child) => child.id !== removeChildId);
 
   saveProtectedApplicationState({
     params,
@@ -135,7 +137,7 @@ export async function action({ context, params, request, url }: Route.ActionArgs
     },
   });
 
-  return redirect(getPathById(`protected/application/$id/${state.context}-${state.typeOfApplication}/childrens-application`, params));
+  return { operation: FORM_ACTION.remove, childNumber: removedIndex + 1, childName: removedChildName, removedIndex };
 }
 
 export default function ProtectedNewChildChildrensApplication({ loaderData, params }: Route.ComponentProps) {
@@ -146,12 +148,33 @@ export default function ProtectedNewChildChildrensApplication({ loaderData, para
   const { isSubmitting } = useFetcherSubmissionState(fetcher);
 
   useFetcherActionComplete(fetcher, (actionData) => {
+    if (actionData.operation === FORM_ACTION.add) {
+      announce(
+        t(($) => $.childrensApplication.childAddedAnnouncement, { childNumber: actionData.childNumber }),
+        'polite',
+      );
+      window.requestAnimationFrame(() => {
+        document.querySelector<HTMLElement>(`#child-heading-${CSS.escape(actionData.childId)}`)?.focus({ preventScroll: true });
+      });
+      return;
+    }
+
     announce(
-      t(($) => $.childrensApplication.childAddedAnnouncement, { childNumber: actionData.childNumber }),
+      actionData.childName
+        ? t(($) => $.childrensApplication.childRemovedAnnouncementWithName, { childNumber: actionData.childNumber, childName: actionData.childName })
+        : t(($) => $.childrensApplication.childRemovedAnnouncement, { childNumber: actionData.childNumber }),
       'polite',
     );
     window.requestAnimationFrame(() => {
-      document.querySelector<HTMLElement>(`#child-heading-${CSS.escape(actionData.childId)}`)?.focus({ preventScroll: true });
+      const nextChild = state.children[actionData.removedIndex];
+      const previousChild = state.children[actionData.removedIndex - 1];
+      if (nextChild) {
+        document.querySelector<HTMLElement>(`#child-heading-${CSS.escape(nextChild.id)}`)?.focus({ preventScroll: true });
+      } else if (previousChild) {
+        document.querySelector<HTMLElement>(`#child-heading-${CSS.escape(previousChild.id)}`)?.focus({ preventScroll: true });
+      } else {
+        document.querySelector<HTMLElement>('#add-child')?.focus({ preventScroll: true });
+      }
     });
   });
 

--- a/frontend/app/routes/protected/application/intake-children/childrens-application.tsx
+++ b/frontend/app/routes/protected/application/intake-children/childrens-application.tsx
@@ -12,7 +12,7 @@ import { TYPES } from '~/.server/constants';
 import { appContext } from '~/.server/context';
 import { loadProtectedApplicationIntakeChildState } from '~/.server/routes/helpers/protected-application-intake-child-route-helpers';
 import { isChildDentalBenefitsSectionCompleted, isChildDentalInsuranceSectionCompleted, isChildInformationSectionCompleted } from '~/.server/routes/helpers/protected-application-intake-section-checks';
-import { saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
+import { removeChildState, saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale-utils';
 import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
@@ -123,21 +123,10 @@ export async function action({ context, params, request, url }: Route.ActionArgs
     return { operation: FORM_ACTION.add, childId, childNumber: children.length };
   }
 
-  const removeChildId = formData.get('childId');
-  const removedIndex = state.children.findIndex((child) => child.id === removeChildId);
-  const removedChild = state.children[removedIndex];
-  const removedChildName = removedChild?.information ? `${removedChild.information.firstName} ${removedChild.information.lastName}` : undefined;
-  const children = state.children.filter((child) => child.id !== removeChildId);
+  const removeChildId = String(formData.get('childId'));
+  const { removedIndex, childNumber, childName } = removeChildState({ params, session, childId: removeChildId });
 
-  saveProtectedApplicationState({
-    params,
-    session,
-    state: {
-      children: children,
-    },
-  });
-
-  return { operation: FORM_ACTION.remove, childNumber: removedIndex + 1, childName: removedChildName, removedIndex };
+  return { operation: FORM_ACTION.remove, childNumber, childName, removedIndex };
 }
 
 export default function ProtectedNewChildChildrensApplication({ loaderData, params }: Route.ComponentProps) {

--- a/frontend/app/routes/protected/application/intake-family/childrens-application.tsx
+++ b/frontend/app/routes/protected/application/intake-family/childrens-application.tsx
@@ -1,4 +1,4 @@
-import { redirect, useFetcher } from 'react-router';
+import { useFetcher } from 'react-router';
 
 import { invariant } from '@dts-stn/invariant';
 import { faCirclePlus, faPenToSquare } from '@fortawesome/free-solid-svg-icons';
@@ -27,7 +27,6 @@ import { ProgressStepper } from '~/routes/protected/application/intake-family/pr
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { generateId } from '~/utils/id-utils';
 import { mergeMeta } from '~/utils/meta-utils';
-import { getPathById } from '~/utils/route-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
@@ -125,7 +124,10 @@ export async function action({ context, params, request, url }: Route.ActionArgs
   }
 
   const removeChildId = formData.get('childId');
-  const children = [...state.children].filter((child) => child.id !== removeChildId);
+  const removedIndex = state.children.findIndex((child) => child.id === removeChildId);
+  const removedChild = state.children[removedIndex];
+  const removedChildName = removedChild?.information ? `${removedChild.information.firstName} ${removedChild.information.lastName}` : undefined;
+  const children = state.children.filter((child) => child.id !== removeChildId);
 
   saveProtectedApplicationState({
     params,
@@ -135,7 +137,7 @@ export async function action({ context, params, request, url }: Route.ActionArgs
     },
   });
 
-  return redirect(getPathById(`protected/application/$id/${state.context}-${state.typeOfApplication}/childrens-application`, params));
+  return { operation: FORM_ACTION.remove, childNumber: removedIndex + 1, childName: removedChildName, removedIndex };
 }
 
 export default function ProtectedNewFamilyChildrensApplication({ loaderData, params }: Route.ComponentProps) {
@@ -146,12 +148,33 @@ export default function ProtectedNewFamilyChildrensApplication({ loaderData, par
   const { isSubmitting } = useFetcherSubmissionState(fetcher);
 
   useFetcherActionComplete(fetcher, (actionData) => {
+    if (actionData.operation === FORM_ACTION.add) {
+      announce(
+        t(($) => $.childrensApplication.childAddedAnnouncement, { childNumber: actionData.childNumber }),
+        'polite',
+      );
+      window.requestAnimationFrame(() => {
+        document.querySelector<HTMLElement>(`#child-heading-${CSS.escape(actionData.childId)}`)?.focus({ preventScroll: true });
+      });
+      return;
+    }
+
     announce(
-      t(($) => $.childrensApplication.childAddedAnnouncement, { childNumber: actionData.childNumber }),
+      actionData.childName
+        ? t(($) => $.childrensApplication.childRemovedAnnouncementWithName, { childNumber: actionData.childNumber, childName: actionData.childName })
+        : t(($) => $.childrensApplication.childRemovedAnnouncement, { childNumber: actionData.childNumber }),
       'polite',
     );
     window.requestAnimationFrame(() => {
-      document.querySelector<HTMLElement>(`#child-heading-${CSS.escape(actionData.childId)}`)?.focus({ preventScroll: true });
+      const nextChild = state.children[actionData.removedIndex];
+      const previousChild = state.children[actionData.removedIndex - 1];
+      if (nextChild) {
+        document.querySelector<HTMLElement>(`#child-heading-${CSS.escape(nextChild.id)}`)?.focus({ preventScroll: true });
+      } else if (previousChild) {
+        document.querySelector<HTMLElement>(`#child-heading-${CSS.escape(previousChild.id)}`)?.focus({ preventScroll: true });
+      } else {
+        document.querySelector<HTMLElement>('#add-child')?.focus({ preventScroll: true });
+      }
     });
   });
 

--- a/frontend/app/routes/protected/application/intake-family/childrens-application.tsx
+++ b/frontend/app/routes/protected/application/intake-family/childrens-application.tsx
@@ -12,7 +12,7 @@ import { TYPES } from '~/.server/constants';
 import { appContext } from '~/.server/context';
 import { loadProtectedApplicationIntakeFamilyState } from '~/.server/routes/helpers/protected-application-intake-family-route-helpers';
 import { isChildDentalBenefitsSectionCompleted, isChildDentalInsuranceSectionCompleted, isChildInformationSectionCompleted } from '~/.server/routes/helpers/protected-application-intake-section-checks';
-import { saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
+import { removeChildState, saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale-utils';
 import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
@@ -123,21 +123,10 @@ export async function action({ context, params, request, url }: Route.ActionArgs
     return { operation: FORM_ACTION.add, childId, childNumber: children.length };
   }
 
-  const removeChildId = formData.get('childId');
-  const removedIndex = state.children.findIndex((child) => child.id === removeChildId);
-  const removedChild = state.children[removedIndex];
-  const removedChildName = removedChild?.information ? `${removedChild.information.firstName} ${removedChild.information.lastName}` : undefined;
-  const children = state.children.filter((child) => child.id !== removeChildId);
+  const removeChildId = String(formData.get('childId'));
+  const { removedIndex, childNumber, childName } = removeChildState({ params, session, childId: removeChildId });
 
-  saveProtectedApplicationState({
-    params,
-    session,
-    state: {
-      children: children,
-    },
-  });
-
-  return { operation: FORM_ACTION.remove, childNumber: removedIndex + 1, childName: removedChildName, removedIndex };
+  return { operation: FORM_ACTION.remove, childNumber, childName, removedIndex };
 }
 
 export default function ProtectedNewFamilyChildrensApplication({ loaderData, params }: Route.ComponentProps) {

--- a/frontend/app/routes/public/application/full-children/childrens-application.tsx
+++ b/frontend/app/routes/public/application/full-children/childrens-application.tsx
@@ -1,4 +1,4 @@
-import { redirect, useFetcher } from 'react-router';
+import { useFetcher } from 'react-router';
 
 import { invariant } from '@dts-stn/invariant';
 import { faCirclePlus, faPenToSquare } from '@fortawesome/free-solid-svg-icons';
@@ -27,7 +27,6 @@ import { ProgressStepper } from '~/routes/public/application/full-children/progr
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { generateId } from '~/utils/id-utils';
 import { mergeMeta } from '~/utils/meta-utils';
-import { getPathById } from '~/utils/route-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
@@ -124,7 +123,10 @@ export async function action({ context, params, request, url }: Route.ActionArgs
   }
 
   const removeChildId = formData.get('childId');
-  const children = [...state.children].filter((child) => child.id !== removeChildId);
+  const removedIndex = state.children.findIndex((child) => child.id === removeChildId);
+  const removedChild = state.children[removedIndex];
+  const removedChildName = removedChild?.information ? `${removedChild.information.firstName} ${removedChild.information.lastName}` : undefined;
+  const children = state.children.filter((child) => child.id !== removeChildId);
 
   savePublicApplicationState({
     params,
@@ -134,7 +136,7 @@ export async function action({ context, params, request, url }: Route.ActionArgs
     },
   });
 
-  return redirect(getPathById(`public/application/$id/${state.inputModel}-${state.typeOfApplication}/childrens-application`, params));
+  return { operation: FORM_ACTION.remove, childNumber: removedIndex + 1, childName: removedChildName, removedIndex };
 }
 
 export default function NewChildChildrensApplication({ loaderData, params }: Route.ComponentProps) {
@@ -145,12 +147,33 @@ export default function NewChildChildrensApplication({ loaderData, params }: Rou
   const { isSubmitting } = useFetcherSubmissionState(fetcher);
 
   useFetcherActionComplete(fetcher, (actionData) => {
+    if (actionData.operation === FORM_ACTION.add) {
+      announce(
+        t(($) => $.childrensApplication.childAddedAnnouncement, { childNumber: actionData.childNumber }),
+        'polite',
+      );
+      window.requestAnimationFrame(() => {
+        document.querySelector<HTMLElement>(`#child-heading-${CSS.escape(actionData.childId)}`)?.focus({ preventScroll: true });
+      });
+      return;
+    }
+
     announce(
-      t(($) => $.childrensApplication.childAddedAnnouncement, { childNumber: actionData.childNumber }),
+      actionData.childName
+        ? t(($) => $.childrensApplication.childRemovedAnnouncementWithName, { childNumber: actionData.childNumber, childName: actionData.childName })
+        : t(($) => $.childrensApplication.childRemovedAnnouncement, { childNumber: actionData.childNumber }),
       'polite',
     );
     window.requestAnimationFrame(() => {
-      document.querySelector<HTMLElement>(`#child-heading-${CSS.escape(actionData.childId)}`)?.focus({ preventScroll: true });
+      const nextChild = state.children[actionData.removedIndex];
+      const previousChild = state.children[actionData.removedIndex - 1];
+      if (nextChild) {
+        document.querySelector<HTMLElement>(`#child-heading-${CSS.escape(nextChild.id)}`)?.focus({ preventScroll: true });
+      } else if (previousChild) {
+        document.querySelector<HTMLElement>(`#child-heading-${CSS.escape(previousChild.id)}`)?.focus({ preventScroll: true });
+      } else {
+        document.querySelector<HTMLElement>('#add-child')?.focus({ preventScroll: true });
+      }
     });
   });
 

--- a/frontend/app/routes/public/application/full-children/childrens-application.tsx
+++ b/frontend/app/routes/public/application/full-children/childrens-application.tsx
@@ -12,7 +12,7 @@ import { TYPES } from '~/.server/constants';
 import { appContext } from '~/.server/context';
 import { loadPublicApplicationFullChildState } from '~/.server/routes/helpers/public-application-full-child-route-helpers';
 import { isChildDentalBenefitsSectionCompleted, isChildDentalInsuranceSectionCompleted, isChildInformationSectionCompleted } from '~/.server/routes/helpers/public-application-full-section-checks';
-import { savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
+import { removeChildState, savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale-utils';
 import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
@@ -122,21 +122,10 @@ export async function action({ context, params, request, url }: Route.ActionArgs
     return { operation: FORM_ACTION.add, childId, childNumber: children.length };
   }
 
-  const removeChildId = formData.get('childId');
-  const removedIndex = state.children.findIndex((child) => child.id === removeChildId);
-  const removedChild = state.children[removedIndex];
-  const removedChildName = removedChild?.information ? `${removedChild.information.firstName} ${removedChild.information.lastName}` : undefined;
-  const children = state.children.filter((child) => child.id !== removeChildId);
+  const removeChildId = String(formData.get('childId'));
+  const { removedIndex, childNumber, childName } = removeChildState({ params, session, childId: removeChildId });
 
-  savePublicApplicationState({
-    params,
-    session,
-    state: {
-      children: children,
-    },
-  });
-
-  return { operation: FORM_ACTION.remove, childNumber: removedIndex + 1, childName: removedChildName, removedIndex };
+  return { operation: FORM_ACTION.remove, childNumber, childName, removedIndex };
 }
 
 export default function NewChildChildrensApplication({ loaderData, params }: Route.ComponentProps) {

--- a/frontend/app/routes/public/application/full-family/childrens-application.tsx
+++ b/frontend/app/routes/public/application/full-family/childrens-application.tsx
@@ -1,4 +1,4 @@
-import { redirect, useFetcher } from 'react-router';
+import { useFetcher } from 'react-router';
 
 import { invariant } from '@dts-stn/invariant';
 import { faCirclePlus, faPenToSquare } from '@fortawesome/free-solid-svg-icons';
@@ -27,7 +27,6 @@ import { ProgressStepper } from '~/routes/public/application/full-family/progres
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { generateId } from '~/utils/id-utils';
 import { mergeMeta } from '~/utils/meta-utils';
-import { getPathById } from '~/utils/route-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
@@ -125,7 +124,10 @@ export async function action({ context, params, request, url }: Route.ActionArgs
   }
 
   const removeChildId = formData.get('childId');
-  const children = [...state.children].filter((child) => child.id !== removeChildId);
+  const removedIndex = state.children.findIndex((child) => child.id === removeChildId);
+  const removedChild = state.children[removedIndex];
+  const removedChildName = removedChild?.information ? `${removedChild.information.firstName} ${removedChild.information.lastName}` : undefined;
+  const children = state.children.filter((child) => child.id !== removeChildId);
 
   savePublicApplicationState({
     params,
@@ -135,7 +137,7 @@ export async function action({ context, params, request, url }: Route.ActionArgs
     },
   });
 
-  return redirect(getPathById(`public/application/$id/${state.inputModel}-${state.typeOfApplication}/childrens-application`, params));
+  return { operation: FORM_ACTION.remove, childNumber: removedIndex + 1, childName: removedChildName, removedIndex };
 }
 
 export default function NewFamilyChildrensApplication({ loaderData, params }: Route.ComponentProps) {
@@ -146,12 +148,33 @@ export default function NewFamilyChildrensApplication({ loaderData, params }: Ro
   const { isSubmitting } = useFetcherSubmissionState(fetcher);
 
   useFetcherActionComplete(fetcher, (actionData) => {
+    if (actionData.operation === FORM_ACTION.add) {
+      announce(
+        t(($) => $.childrensApplication.childAddedAnnouncement, { childNumber: actionData.childNumber }),
+        'polite',
+      );
+      window.requestAnimationFrame(() => {
+        document.querySelector<HTMLElement>(`#child-heading-${CSS.escape(actionData.childId)}`)?.focus({ preventScroll: true });
+      });
+      return;
+    }
+
     announce(
-      t(($) => $.childrensApplication.childAddedAnnouncement, { childNumber: actionData.childNumber }),
+      actionData.childName
+        ? t(($) => $.childrensApplication.childRemovedAnnouncementWithName, { childNumber: actionData.childNumber, childName: actionData.childName })
+        : t(($) => $.childrensApplication.childRemovedAnnouncement, { childNumber: actionData.childNumber }),
       'polite',
     );
     window.requestAnimationFrame(() => {
-      document.querySelector<HTMLElement>(`#child-heading-${CSS.escape(actionData.childId)}`)?.focus({ preventScroll: true });
+      const nextChild = state.children[actionData.removedIndex];
+      const previousChild = state.children[actionData.removedIndex - 1];
+      if (nextChild) {
+        document.querySelector<HTMLElement>(`#child-heading-${CSS.escape(nextChild.id)}`)?.focus({ preventScroll: true });
+      } else if (previousChild) {
+        document.querySelector<HTMLElement>(`#child-heading-${CSS.escape(previousChild.id)}`)?.focus({ preventScroll: true });
+      } else {
+        document.querySelector<HTMLElement>('#add-child')?.focus({ preventScroll: true });
+      }
     });
   });
 

--- a/frontend/app/routes/public/application/full-family/childrens-application.tsx
+++ b/frontend/app/routes/public/application/full-family/childrens-application.tsx
@@ -12,7 +12,7 @@ import { TYPES } from '~/.server/constants';
 import { appContext } from '~/.server/context';
 import { loadPublicApplicationFullFamilyState } from '~/.server/routes/helpers/public-application-full-family-route-helpers';
 import { isChildDentalBenefitsSectionCompleted, isChildDentalInsuranceSectionCompleted, isChildInformationSectionCompleted } from '~/.server/routes/helpers/public-application-full-section-checks';
-import { savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
+import { removeChildState, savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale-utils';
 import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
@@ -123,21 +123,10 @@ export async function action({ context, params, request, url }: Route.ActionArgs
     return { operation: FORM_ACTION.add, childId, childNumber: children.length };
   }
 
-  const removeChildId = formData.get('childId');
-  const removedIndex = state.children.findIndex((child) => child.id === removeChildId);
-  const removedChild = state.children[removedIndex];
-  const removedChildName = removedChild?.information ? `${removedChild.information.firstName} ${removedChild.information.lastName}` : undefined;
-  const children = state.children.filter((child) => child.id !== removeChildId);
+  const removeChildId = String(formData.get('childId'));
+  const { removedIndex, childNumber, childName } = removeChildState({ params, session, childId: removeChildId });
 
-  savePublicApplicationState({
-    params,
-    session,
-    state: {
-      children: children,
-    },
-  });
-
-  return { operation: FORM_ACTION.remove, childNumber: removedIndex + 1, childName: removedChildName, removedIndex };
+  return { operation: FORM_ACTION.remove, childNumber, childName, removedIndex };
 }
 
 export default function NewFamilyChildrensApplication({ loaderData, params }: Route.ComponentProps) {

--- a/frontend/app/routes/public/application/simplified-children/childrens-application.tsx
+++ b/frontend/app/routes/public/application/simplified-children/childrens-application.tsx
@@ -1,4 +1,4 @@
-import { data, redirect, useFetcher } from 'react-router';
+import { data, useFetcher } from 'react-router';
 
 import { invariant } from '@dts-stn/invariant';
 import { faCircleCheck, faPenToSquare } from '@fortawesome/free-regular-svg-icons';
@@ -28,7 +28,6 @@ import { ProgressStepper } from '~/routes/public/application/simplified-children
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { generateId } from '~/utils/id-utils';
 import { mergeMeta } from '~/utils/meta-utils';
-import { getPathById } from '~/utils/route-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
@@ -129,7 +128,10 @@ export async function action({ context, params, request, url }: Route.ActionArgs
 
   if (formAction === FORM_ACTION.remove) {
     const removeChildId = formData.get('childId');
-    const children = [...state.children].filter((child) => child.id !== removeChildId);
+    const removedIndex = state.children.findIndex((child) => child.id === removeChildId);
+    const removedChild = state.children[removedIndex];
+    const removedChildName = removedChild?.information ? `${removedChild.information.firstName} ${removedChild.information.lastName}` : undefined;
+    const children = state.children.filter((child) => child.id !== removeChildId);
 
     savePublicApplicationState({
       params,
@@ -138,28 +140,26 @@ export async function action({ context, params, request, url }: Route.ActionArgs
         children: children,
       },
     });
+
+    return { operation: FORM_ACTION.remove, childNumber: removedIndex + 1, childName: removedChildName, removedIndex };
   }
 
-  if (formAction === FORM_ACTION.DENTAL_BENEFITS_NOT_CHANGED) {
-    const childId = formData.get('childId');
-    savePublicApplicationState({
-      params,
-      session,
-      state: {
-        children: state.children.map((child) => {
-          if (child.id !== childId) return child;
-          return {
-            ...child,
-            dentalBenefits: { hasChanged: false },
-          };
-        }),
-      },
-    });
+  const childId = formData.get('childId');
+  savePublicApplicationState({
+    params,
+    session,
+    state: {
+      children: state.children.map((child) => {
+        if (child.id !== childId) return child;
+        return {
+          ...child,
+          dentalBenefits: { hasChanged: false },
+        };
+      }),
+    },
+  });
 
-    return data({ success: true }, { status: 200 });
-  }
-
-  return redirect(getPathById(`public/application/$id/${state.inputModel}-${state.typeOfApplication}/childrens-application`, params));
+  return data({ success: true }, { status: 200 });
 }
 
 export default function RenewChildChildrensApplication({ loaderData, params }: Route.ComponentProps) {
@@ -174,12 +174,33 @@ export default function RenewChildChildrensApplication({ loaderData, params }: R
       return;
     }
 
+    if (actionData.operation === FORM_ACTION.add) {
+      announce(
+        t(($) => $.childrensApplication.childAddedAnnouncement, { childNumber: actionData.childNumber }),
+        'polite',
+      );
+      window.requestAnimationFrame(() => {
+        document.querySelector<HTMLElement>(`#child-heading-${CSS.escape(actionData.childId)}`)?.focus({ preventScroll: true });
+      });
+      return;
+    }
+
     announce(
-      t(($) => $.childrensApplication.childAddedAnnouncement, { childNumber: actionData.childNumber }),
+      actionData.childName
+        ? t(($) => $.childrensApplication.childRemovedAnnouncementWithName, { childNumber: actionData.childNumber, childName: actionData.childName })
+        : t(($) => $.childrensApplication.childRemovedAnnouncement, { childNumber: actionData.childNumber }),
       'polite',
     );
     window.requestAnimationFrame(() => {
-      document.querySelector<HTMLElement>(`#child-heading-${CSS.escape(actionData.childId)}`)?.focus({ preventScroll: true });
+      const nextChild = state.children[actionData.removedIndex];
+      const previousChild = state.children[actionData.removedIndex - 1];
+      if (nextChild) {
+        document.querySelector<HTMLElement>(`#child-heading-${CSS.escape(nextChild.id)}`)?.focus({ preventScroll: true });
+      } else if (previousChild) {
+        document.querySelector<HTMLElement>(`#child-heading-${CSS.escape(previousChild.id)}`)?.focus({ preventScroll: true });
+      } else {
+        document.querySelector<HTMLElement>('#add-child')?.focus({ preventScroll: true });
+      }
     });
   });
 

--- a/frontend/app/routes/public/application/simplified-children/childrens-application.tsx
+++ b/frontend/app/routes/public/application/simplified-children/childrens-application.tsx
@@ -11,7 +11,7 @@ import type { Route } from './+types/childrens-application';
 
 import { TYPES } from '~/.server/constants';
 import { appContext } from '~/.server/context';
-import { savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
+import { removeChildState, savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { loadPublicApplicationSimplifiedChildState } from '~/.server/routes/helpers/public-application-simplified-child-route-helpers';
 import { isChildDentalBenefitsSectionCompleted, isChildDentalInsuranceSectionCompleted, isChildInformationSectionCompleted } from '~/.server/routes/helpers/public-application-simplified-section-checks';
 import { getFixedT, getLocale } from '~/.server/utils/locale-utils';
@@ -127,21 +127,10 @@ export async function action({ context, params, request, url }: Route.ActionArgs
   }
 
   if (formAction === FORM_ACTION.remove) {
-    const removeChildId = formData.get('childId');
-    const removedIndex = state.children.findIndex((child) => child.id === removeChildId);
-    const removedChild = state.children[removedIndex];
-    const removedChildName = removedChild?.information ? `${removedChild.information.firstName} ${removedChild.information.lastName}` : undefined;
-    const children = state.children.filter((child) => child.id !== removeChildId);
+    const removeChildId = String(formData.get('childId'));
+    const { removedIndex, childNumber, childName } = removeChildState({ params, session, childId: removeChildId });
 
-    savePublicApplicationState({
-      params,
-      session,
-      state: {
-        children: children,
-      },
-    });
-
-    return { operation: FORM_ACTION.remove, childNumber: removedIndex + 1, childName: removedChildName, removedIndex };
+    return { operation: FORM_ACTION.remove, childNumber, childName, removedIndex };
   }
 
   const childId = formData.get('childId');

--- a/frontend/app/routes/public/application/simplified-family/childrens-application.tsx
+++ b/frontend/app/routes/public/application/simplified-family/childrens-application.tsx
@@ -1,4 +1,4 @@
-import { data, redirect, useFetcher } from 'react-router';
+import { data, useFetcher } from 'react-router';
 
 import { invariant } from '@dts-stn/invariant';
 import { faCircleCheck, faPenToSquare } from '@fortawesome/free-regular-svg-icons';
@@ -28,7 +28,6 @@ import { ProgressStepper } from '~/routes/public/application/simplified-family/p
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { generateId } from '~/utils/id-utils';
 import { mergeMeta } from '~/utils/meta-utils';
-import { getPathById } from '~/utils/route-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
@@ -128,7 +127,10 @@ export async function action({ context, params, request, url }: Route.ActionArgs
 
   if (formAction === FORM_ACTION.remove) {
     const removeChildId = formData.get('childId');
-    const children = [...state.children].filter((child) => child.id !== removeChildId);
+    const removedIndex = state.children.findIndex((child) => child.id === removeChildId);
+    const removedChild = state.children[removedIndex];
+    const removedChildName = removedChild?.information ? `${removedChild.information.firstName} ${removedChild.information.lastName}` : undefined;
+    const children = state.children.filter((child) => child.id !== removeChildId);
 
     savePublicApplicationState({
       params,
@@ -137,28 +139,26 @@ export async function action({ context, params, request, url }: Route.ActionArgs
         children: children,
       },
     });
+
+    return { operation: FORM_ACTION.remove, childNumber: removedIndex + 1, childName: removedChildName, removedIndex };
   }
 
-  if (formAction === FORM_ACTION.DENTAL_BENEFITS_NOT_CHANGED) {
-    const childId = formData.get('childId');
-    savePublicApplicationState({
-      params,
-      session,
-      state: {
-        children: state.children.map((child) => {
-          if (child.id !== childId) return child;
-          return {
-            ...child,
-            dentalBenefits: { hasChanged: false },
-          };
-        }),
-      },
-    });
+  const childId = formData.get('childId');
+  savePublicApplicationState({
+    params,
+    session,
+    state: {
+      children: state.children.map((child) => {
+        if (child.id !== childId) return child;
+        return {
+          ...child,
+          dentalBenefits: { hasChanged: false },
+        };
+      }),
+    },
+  });
 
-    return data({ success: true }, { status: 200 });
-  }
-
-  return redirect(getPathById(`public/application/$id/${state.inputModel}-${state.typeOfApplication}/childrens-application`, params));
+  return data({ success: true }, { status: 200 });
 }
 
 export default function RenewFamilyChildrensApplication({ loaderData, params }: Route.ComponentProps) {
@@ -173,12 +173,33 @@ export default function RenewFamilyChildrensApplication({ loaderData, params }: 
       return;
     }
 
+    if (actionData.operation === FORM_ACTION.add) {
+      announce(
+        t(($) => $.childrensApplication.childAddedAnnouncement, { childNumber: actionData.childNumber }),
+        'polite',
+      );
+      window.requestAnimationFrame(() => {
+        document.querySelector<HTMLElement>(`#child-heading-${CSS.escape(actionData.childId)}`)?.focus({ preventScroll: true });
+      });
+      return;
+    }
+
     announce(
-      t(($) => $.childrensApplication.childAddedAnnouncement, { childNumber: actionData.childNumber }),
+      actionData.childName
+        ? t(($) => $.childrensApplication.childRemovedAnnouncementWithName, { childNumber: actionData.childNumber, childName: actionData.childName })
+        : t(($) => $.childrensApplication.childRemovedAnnouncement, { childNumber: actionData.childNumber }),
       'polite',
     );
     window.requestAnimationFrame(() => {
-      document.querySelector<HTMLElement>(`#child-heading-${CSS.escape(actionData.childId)}`)?.focus({ preventScroll: true });
+      const nextChild = state.children[actionData.removedIndex];
+      const previousChild = state.children[actionData.removedIndex - 1];
+      if (nextChild) {
+        document.querySelector<HTMLElement>(`#child-heading-${CSS.escape(nextChild.id)}`)?.focus({ preventScroll: true });
+      } else if (previousChild) {
+        document.querySelector<HTMLElement>(`#child-heading-${CSS.escape(previousChild.id)}`)?.focus({ preventScroll: true });
+      } else {
+        document.querySelector<HTMLElement>('#add-child')?.focus({ preventScroll: true });
+      }
     });
   });
 

--- a/frontend/app/routes/public/application/simplified-family/childrens-application.tsx
+++ b/frontend/app/routes/public/application/simplified-family/childrens-application.tsx
@@ -11,7 +11,7 @@ import type { Route } from './+types/childrens-application';
 
 import { TYPES } from '~/.server/constants';
 import { appContext } from '~/.server/context';
-import { savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
+import { removeChildState, savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { loadPublicApplicationSimplifiedFamilyState } from '~/.server/routes/helpers/public-application-simplified-family-route-helpers';
 import { isChildDentalBenefitsSectionCompleted, isChildDentalInsuranceSectionCompleted, isChildInformationSectionCompleted } from '~/.server/routes/helpers/public-application-simplified-section-checks';
 import { getFixedT, getLocale } from '~/.server/utils/locale-utils';
@@ -126,21 +126,10 @@ export async function action({ context, params, request, url }: Route.ActionArgs
   }
 
   if (formAction === FORM_ACTION.remove) {
-    const removeChildId = formData.get('childId');
-    const removedIndex = state.children.findIndex((child) => child.id === removeChildId);
-    const removedChild = state.children[removedIndex];
-    const removedChildName = removedChild?.information ? `${removedChild.information.firstName} ${removedChild.information.lastName}` : undefined;
-    const children = state.children.filter((child) => child.id !== removeChildId);
+    const removeChildId = String(formData.get('childId'));
+    const { removedIndex, childNumber, childName } = removeChildState({ params, session, childId: removeChildId });
 
-    savePublicApplicationState({
-      params,
-      session,
-      state: {
-        children: children,
-      },
-    });
-
-    return { operation: FORM_ACTION.remove, childNumber: removedIndex + 1, childName: removedChildName, removedIndex };
+    return { operation: FORM_ACTION.remove, childNumber, childName, removedIndex };
   }
 
   const childId = formData.get('childId');


### PR DESCRIPTION
### Description

Removing a child from a children's application incorrectly announced
"Child X was added successfully" to screen readers. This updates the remove
flow to return structured action data and announce the correct message.

This is part 4/4 of the requirement from @sebastien-comeau on #5344 

### Screenshots (if applicable)

<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist

<!-- Go through each item and check it with an "x" inside the square brackets. -->

- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `pnpm run format:check`
- [ ] I have checked that my code contains no linting errors by running `pnpm run lint`
- [ ] I have checked that my code contains no type errors by running `pnpm run typecheck`
- [ ] I have checked that all unit tests pass by running `pnpm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `pnpm run test:e2e`

### Test Instructions

<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes

<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->
